### PR TITLE
Mozjs52 update

### DIFF
--- a/c_src/mozjs_nif.cpp
+++ b/c_src/mozjs_nif.cpp
@@ -34,6 +34,8 @@ static ERL_NIF_TERM mozjs_init(ErlNifEnv* env, int argc,
                                    const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM mozjs_eval(ErlNifEnv* env, int argc,
                                    const ERL_NIF_TERM argv[]);
+static ERL_NIF_TERM mozjs_cancel(ErlNifEnv* env, int argc,
+                                   const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM mozjs_stop(ErlNifEnv* env, int argc,
                                    const ERL_NIF_TERM argv[]);
 
@@ -41,6 +43,7 @@ static ErlNifFunc nif_funcs[] =
 {
     {"sm_init", 2, mozjs_init, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"sm_eval_nif", 4, mozjs_eval, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"sm_cancel", 1, mozjs_cancel, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"sm_stop", 1, mozjs_stop, ERL_NIF_DIRTY_JOB_CPU_BOUND}
 };
 
@@ -101,6 +104,21 @@ static ERL_NIF_TERM mozjs_eval(ErlNifEnv* env, int argc,
     return atom_ok;
 }
 
+static ERL_NIF_TERM mozjs_cancel(ErlNifEnv* env, int argc,
+                                          const ERL_NIF_TERM argv[])
+{
+    mozjs_handle* handle = nullptr;
+
+    if (!enif_get_resource(env, argv[0], mozjs_RESOURCE, (void**)&handle))
+        return enif_make_badarg(env);
+
+    if (handle->vm == nullptr)
+        return enif_make_tuple2(env, atom_error, atom_noinit);
+
+    handle->vm->sm_stop();
+
+    return atom_ok;
+}
 static ERL_NIF_TERM mozjs_stop(ErlNifEnv* env, int argc,
                                           const ERL_NIF_TERM argv[])
 {

--- a/c_src/spidermonkey.cpp
+++ b/c_src/spidermonkey.cpp
@@ -198,13 +198,11 @@ void spidermonkey_vm::sm_stop() {
   spidermonkey_state *state = (spidermonkey_state *) JS_GetContextPrivate(this->context);
   state->terminate = true;
   JS_SetContextPrivate(this->context, state);
-
-  //Wait for any executing function to stop
-  //before beginning to free up any memory.
-  while (JS_IsRunning(this->context))
-      sleep(1);
-
   JS_EndRequest(this->context);
+
+  // Request interrupt callback immediately. This call is thread-safe and can
+  // be called outside of JS_BeginRequest/JS_EndRequest.
+  JS_RequestInterruptCallback(this->context);
 }
 
 bool spidermonkey_vm::sm_eval(const char *filename, size_t filename_length, const char *code, size_t code_length, char** output, int handle_retval) {

--- a/src/js_driver.erl
+++ b/src/js_driver.erl
@@ -113,6 +113,8 @@ exec_js(Ctx, FileName, Js, _Jsonify, HandleRetval) when is_binary(FileName), is_
     case mozjs_nif:sm_eval(Ctx, FileName, Js, HandleRetval) of
         ok ->
             ok;
+	{ok, <<"undefined">>} ->
+            {error, mozjs_script_interrupted};
         {ok, Result} ->
             {ok, mochijson2:decode(Result)};
         {error, ErrorJson} when is_binary(ErrorJson) ->

--- a/src/mozjs_nif.erl
+++ b/src/mozjs_nif.erl
@@ -2,6 +2,7 @@
 
 -export([sm_init/2,
          sm_eval/4,
+         sm_cancel/1,
          sm_stop/1]).
 
 -on_load(init/0).
@@ -28,6 +29,8 @@ sm_eval(Ref, Filename, Js, HandleRetval)  when is_list(Js) ->
 sm_eval(Ref, Filename, Js, HandleRetval) ->
     sm_eval_nif(Ref, Filename, Js, HandleRetval).
 sm_eval_nif(_Ref, _Filename, _Js, _HandleRetval) ->
+    ?nif_stub.
+sm_cancel(_Ref) ->
     ?nif_stub.
 sm_stop(_Ref) ->
     ?nif_stub.

--- a/test/api_tests.erl
+++ b/test/api_tests.erl
@@ -1,0 +1,35 @@
+-module(api_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+endless_loop_basic_interrupt_test() ->
+	{ok, Handle} = mozjs_nif:sm_init(8, 8),
+	js:define(Handle, <<"function infinite_foo_1() { for (;;) {} };">>),
+	spawn(
+		fun() ->
+			catch js:eval(Handle, <<"infinite_foo_1();">>)
+		end
+	),
+	timer:sleep(500),
+	?assertEqual(ok, mozjs_nif:sm_cancel(Handle)).
+
+endless_loop_basic_interrupt_with_return_test() ->
+	{ok, Handle} = mozjs_nif:sm_init(8, 8),
+	js:define(Handle, <<"function infinite_foo_2() { for (;;) {} };">>),
+	Pid = self(),
+	spawn(
+		fun() ->
+			Ret = (catch js:eval(Handle, <<"infinite_foo_2();">>)),
+			ok = mozjs_nif:sm_cancel(Handle),
+			Pid ! Ret
+		end
+	),
+	timer:sleep(500),
+	mozjs_nif:sm_cancel(Handle),
+	Ret = receive
+		Something -> Something
+	after
+		1000 -> timeout
+	end,
+	?assertEqual({error, mozjs_script_interrupted}, Ret).


### PR DESCRIPTION
Basically this PR removes obsolete function JS_IsRunning which was removed from mozjs60 (see mozilla/gecko-dev@44e40b79adf50c540625620813ab1990ce37e4ec).

Also there is an initial proposal of interruptible JS calls.