### PR TITLE
Switch default mozjs to mozjs102

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,6 @@
 
 {port_env, [
              {"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
-             {"DRV_CFLAGS", "$DRV_CFLAGS `pkg-config mozjs-91 --cflags`"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS `pkg-config mozjs-91 --libs`"}
+             {"DRV_CFLAGS", "$DRV_CFLAGS `pkg-config mozjs-102 --cflags`"},
+             {"DRV_LDFLAGS", "$DRV_LDFLAGS `pkg-config mozjs-102 --libs`"}
             ]}.


### PR DESCRIPTION
Testsuite passes just fine (on x86_64 at least), mozjs91 is long unsupported, mozjs102 is the latest LTS with a few months of bugfixes remaining.