### PR TITLE
Potential fix for code scanning alert no. 2: File created without restricting permissions

### DIFF
--- a/c_src/spidermonkey.cpp
+++ b/c_src/spidermonkey.cpp
@@ -8,6 +8,8 @@
 #include <cstring>
 #include <ctime>
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
 #include <js/CompilationAndEvaluation.h>
 #include <js/ContextOptions.h>
@@ -99,22 +101,31 @@ bool js_log(JSContext* cx, unsigned argc, JS::Value* vp)
             return true;
         }
 
-        FILE* fd = fopen(filename.get(), "a+");
-        if (fd)
+        int raw_fd = open(filename.get(), O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
+        if (raw_fd >= 0)
         {
-            const struct tm* tmp;
-            time_t t;
+            FILE* fd = fdopen(raw_fd, "a+");
+            if (fd)
+            {
+                const struct tm* tmp;
+                time_t t;
 
-            t = time(nullptr);
-            tmp = localtime(&t);
-            fprintf(fd, "%02d/%02d/%04d (%02d:%02d:%02d): ", tmp->tm_mon + 1, tmp->tm_mday,
-                    tmp->tm_year + 1900, tmp->tm_hour, tmp->tm_min, tmp->tm_sec);
+                t = time(nullptr);
+                tmp = localtime(&t);
+                fprintf(fd, "%02d/%02d/%04d (%02d:%02d:%02d): ", tmp->tm_mon + 1, tmp->tm_mday,
+                        tmp->tm_year + 1900, tmp->tm_hour, tmp->tm_min, tmp->tm_sec);
 
-            fwrite(output.get(), 1, strlen(output.get()), fd);
-            fwrite("\n", 1, 1, fd);
-            fclose(fd);
+                fwrite(output.get(), 1, strlen(output.get()), fd);
+                fwrite("\n", 1, 1, fd);
+                fclose(fd);
 
-            args.rval().setBoolean(true);
+                args.rval().setBoolean(true);
+            }
+            else
+            {
+                close(raw_fd);
+                args.rval().setBoolean(false);
+            }
         }
         else
         {


### PR DESCRIPTION
Potential fix for [https://github.com/erlang-mozjs/erlang-mozjs/security/code-scanning/2](https://github.com/erlang-mozjs/erlang-mozjs/security/code-scanning/2)

Use a file-creation API that allows explicitly setting restrictive permissions when the file is first created, then convert to `FILE*` for existing logic.

Best fix here (without changing behavior): replace `fopen(..., "a+")` with:
- `open(filename.get(), O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR)` to create/append with owner read-write only (`0600`).
- `fdopen(raw_fd, "a+")` to keep stream-based `fprintf`/`fwrite` code unchanged.
- Ensure error handling closes `raw_fd` if `fdopen` fails.

In `c_src/spidermonkey.cpp`, add needed POSIX headers for `open`/flags and mode constants, and replace only the block around line 102 (`FILE* fd = fopen...`) with the secure open+fdopen flow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
