### PR TITLE
Potential fix for code scanning alert no. 1: Use of potentially dangerous function

### DIFF
--- a/c_src/spidermonkey.cpp
+++ b/c_src/spidermonkey.cpp
@@ -102,19 +102,26 @@ bool js_log(JSContext* cx, unsigned argc, JS::Value* vp)
         FILE* fd = fopen(filename.get(), "a+");
         if (fd)
         {
-            const struct tm* tmp;
+            struct tm tmp;
             time_t t;
 
             t = time(nullptr);
-            tmp = localtime(&t);
-            fprintf(fd, "%02d/%02d/%04d (%02d:%02d:%02d): ", tmp->tm_mon + 1, tmp->tm_mday,
-                    tmp->tm_year + 1900, tmp->tm_hour, tmp->tm_min, tmp->tm_sec);
+            if (localtime_r(&t, &tmp) != nullptr)
+            {
+                fprintf(fd, "%02d/%02d/%04d (%02d:%02d:%02d): ", tmp.tm_mon + 1, tmp.tm_mday,
+                        tmp.tm_year + 1900, tmp.tm_hour, tmp.tm_min, tmp.tm_sec);
 
-            fwrite(output.get(), 1, strlen(output.get()), fd);
-            fwrite("\n", 1, 1, fd);
-            fclose(fd);
+                fwrite(output.get(), 1, strlen(output.get()), fd);
+                fwrite("\n", 1, 1, fd);
+                fclose(fd);
 
-            args.rval().setBoolean(true);
+                args.rval().setBoolean(true);
+            }
+            else
+            {
+                fclose(fd);
+                args.rval().setBoolean(false);
+            }
         }
         else
         {


### PR DESCRIPTION
Potential fix for [https://github.com/erlang-mozjs/erlang-mozjs/security/code-scanning/1](https://github.com/erlang-mozjs/erlang-mozjs/security/code-scanning/1)

Use a caller-provided `struct tm` and replace `localtime` with `localtime_r`, then print from that local struct. Also check the return value of `localtime_r` before dereferencing to avoid null-pointer use on conversion failure.

In `c_src/spidermonkey.cpp`, in `js_log` around the current `time/localtime/fprintf` block (lines 105–111 in the snippet), replace:

- `const struct tm* tmp;`
- `tmp = localtime(&t);`
- direct `tmp->...` access

with:

- `struct tm tmp;`
- `if (localtime_r(&t, &tmp) != nullptr) { ... } else { ... }`
- `tmp....` field access inside the success branch.

Keep behavior unchanged as much as possible: still write log line and return `true` on success; return `false` if timestamp conversion fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
