### PR TITLE
Potential fix for code scanning alert no. 4: File created without restricting permissions

### DIFF
--- a/c_src/spidermonkey.cpp
+++ b/c_src/spidermonkey.cpp
@@ -7,6 +7,8 @@
 
 #include <cstring>
 #include <ctime>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <js/CompilationAndEvaluation.h>
@@ -99,9 +101,17 @@ bool js_log(JSContext* cx, unsigned argc, JS::Value* vp)
             return true;
         }
 
-        FILE* fd = fopen(filename.get(), "a+");
-        if (fd)
+        int raw_fd = open(filename.get(), O_RDWR | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
+        if (raw_fd >= 0)
         {
+            FILE* fd = fdopen(raw_fd, "a+");
+            if (!fd)
+            {
+                close(raw_fd);
+                args.rval().setBoolean(false);
+                return true;
+            }
+
             struct tm tmp;
             time_t t;
 


### PR DESCRIPTION
Potential fix for [https://github.com/erlang-mozjs/erlang-mozjs/security/code-scanning/4](https://github.com/erlang-mozjs/erlang-mozjs/security/code-scanning/4)

Use `open()` with explicit mode bits instead of `fopen()` for file creation, then convert to `FILE*` with `fdopen()` so existing stream-based write logic remains unchanged.

Best fix here (minimal behavior change):
- In `c_src/spidermonkey.cpp`, replace:
  - `FILE* fd = fopen(filename.get(), "a+");`
- With:
  - `int raw_fd = open(filename.get(), O_RDWR | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);`
  - Check `raw_fd >= 0`
  - `FILE* fd = fdopen(raw_fd, "a+");`
  - If `fdopen` fails, `close(raw_fd)` and return false.
This preserves append/read behavior while ensuring newly created files are owner read/write only (`0600`).

Also add required POSIX headers for flags/mode constants:
- `#include <fcntl.h>`
- `#include <sys/stat.h>`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
